### PR TITLE
Delete option(Git account) changes

### DIFF
--- a/internal/sql/GitProviderRepository.go
+++ b/internal/sql/GitProviderRepository.go
@@ -67,12 +67,14 @@ func (impl GitProviderRepositoryImpl) Update(provider *GitProvider) error {
 }
 func (impl GitProviderRepositoryImpl) GetById(id int) (*GitProvider, error) {
 	var provider GitProvider
-	err := impl.dbConnection.Model(&provider).Where("id =? ", id).Select()
+	err := impl.dbConnection.Model(&provider).Where("id =? ", id).
+		Where("active = ?", true).Select()
 	return &provider, err
 }
 
 func (impl GitProviderRepositoryImpl) Exists(id int) (bool, error) {
 	var provider GitProvider
-	exists, err := impl.dbConnection.Model(&provider).Where("id =? ", id).Exists()
+	exists, err := impl.dbConnection.Model(&provider).Where("id =? ", id).
+		Where("active = ?", true).Exists()
 	return exists, err
 }

--- a/scripts/sql/6_alter_delete_options.down.sql
+++ b/scripts/sql/6_alter_delete_options.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE git_provider ADD CONSTRAINT git_provider_name_key UNIQUE (name);
+
+ALTER TABLE git_provider ADD CONSTRAINT git_provider_url_key UNIQUE (url);

--- a/scripts/sql/6_alter_delete_options.up.sql
+++ b/scripts/sql/6_alter_delete_options.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE git_provider DROP CONSTRAINT git_provider_name_key;
+
+ALTER TABLE git_provider DROP CONSTRAINT git_provider_url_key;


### PR DESCRIPTION
For the support of deletion of git account, updated git_provider db table with removal of unique constraint of name and url. Also, updated the query accordingly in git sensor repository.