### PR TITLE
fix : made event type non mandatory in webhook handler

### DIFF
--- a/pkg/git/WebhookHandler.go
+++ b/pkg/git/WebhookHandler.go
@@ -49,7 +49,7 @@ func (impl WebhookHandlerImpl) HandleWebhookEvent(webhookEvent *WebhookEvent) er
 	payloadJson := webhookEvent.RequestPayloadJson
 	payloadId := webhookEvent.PayloadId
 
-	impl.logger.Debugw("gitHostId", gitHostId, "eventType", eventType)
+	impl.logger.Debugw("webhook event request data", "gitHostId", gitHostId, "eventType", eventType)
 
 	// get all configured events from database for given git host Id
 	events, err := impl.webhookEventService.GetAllGitHostWebhookEventByGitHostId(gitHostId)
@@ -66,13 +66,15 @@ func (impl WebhookHandlerImpl) HandleWebhookEvent(webhookEvent *WebhookEvent) er
 	// operate for all matching event (match for eventType)
 	impl.logger.Debug("Checking for event matching")
 	for _, event := range events {
-		eventTypes := strings.Split(event.EventTypesCsv, ",")
-		if !contains(eventTypes, eventType) {
-			continue
+		if len(event.EventTypesCsv) > 0 {
+			eventTypes := strings.Split(event.EventTypesCsv, ",")
+			if !contains(eventTypes, eventType) {
+				continue
+			}
 		}
 
 		eventId := event.Id
-		
+
 		// parse event data using selectors
 		webhookEventParsedData, fullDataMap, err := impl.webhookEventParser.ParseEvent(event.Selectors, payloadJson)
 		if err != nil {


### PR DESCRIPTION
# Description
Made Event type non mandatory in webhook handler to support Azure Devops git provider. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring 

# How Has This Been Tested?
Azure Devops PR webhook

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas


