### PR TITLE
fix: git provider update bug fix

### DIFF
--- a/internal/sql/GitProviderRepository.go
+++ b/internal/sql/GitProviderRepository.go
@@ -74,7 +74,6 @@ func (impl GitProviderRepositoryImpl) GetById(id int) (*GitProvider, error) {
 
 func (impl GitProviderRepositoryImpl) Exists(id int) (bool, error) {
 	var provider GitProvider
-	exists, err := impl.dbConnection.Model(&provider).Where("id =? ", id).
-		Where("active = ?", true).Exists()
+	exists, err := impl.dbConnection.Model(&provider).Where("id =? ", id).Exists()
 	return exists, err
 }


### PR DESCRIPTION
Git provider update was not working due to bug in query to check existing entry for git provider to judge further operation (save or update). 