### PR TITLE
nats client logging added

### DIFF
--- a/internal/NatsClient.go
+++ b/internal/NatsClient.go
@@ -41,7 +41,17 @@ func NewNatsConnection(logger *zap.SugaredLogger) (*PubSubClient, error) {
 		return nil, err
 	}
 
-	nc, err := nats.Connect(cfg.NatsServerHost, nats.ReconnectWait(10*time.Second), nats.MaxReconnects(100))
+	nc, err := nats.Connect(cfg.NatsServerHost,
+		nats.ReconnectWait(10*time.Second), nats.MaxReconnects(100),
+		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+			logger.Errorw("Got disconnected!", "Reason", err)
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			logger.Infow("Got reconnected", "url", nc.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(nc *nats.Conn) {
+			logger.Errorw("Connection closed!", "Reason", nc.LastError())
+		}))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/NatsClient.go
+++ b/internal/NatsClient.go
@@ -44,13 +44,13 @@ func NewNatsConnection(logger *zap.SugaredLogger) (*PubSubClient, error) {
 	nc, err := nats.Connect(cfg.NatsServerHost,
 		nats.ReconnectWait(10*time.Second), nats.MaxReconnects(100),
 		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-			logger.Errorw("Got disconnected!", "Reason", err)
+			logger.Errorw("Nats Connection got disconnected!", "Reason", err)
 		}),
 		nats.ReconnectHandler(func(nc *nats.Conn) {
-			logger.Infow("Got reconnected", "url", nc.ConnectedUrl())
+			logger.Infow("Nats Connection got reconnected", "url", nc.ConnectedUrl())
 		}),
 		nats.ClosedHandler(func(nc *nats.Conn) {
-			logger.Errorw("Connection closed!", "Reason", nc.LastError())
+			logger.Errorw("Nats Client Connection closed!", "Reason", nc.LastError())
 		}))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Logging added for nats client re-connection & disconnection. Would be helpful in debugging any issue. I have also added test cases on NatsClient.

Related to devtron-labs/devtron#1873

## Type of change

- [x] Enhancement

# How Has This Been Tested?

- [x] Restarted Nats Server Pod, checked for both disconnection & reconnection logs.




