### PR TITLE
fix: ssh key directory filemode changed for non-root user to access the ssh key

### DIFF
--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -87,7 +87,7 @@ func GetOrCreateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent stri
 	}
 
 	// create dirs
-	err = os.MkdirAll(sshPrivateKeyFolderPath, 0764)
+	err = os.MkdirAll(sshPrivateKeyFolderPath, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +111,7 @@ func CreateOrUpdateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent s
 	}
 
 	// create dirs
-	err := os.MkdirAll(sshPrivateKeyFolderPath, 0764)
+	err := os.MkdirAll(sshPrivateKeyFolderPath, 0755)
 	if err != nil {
 		return err
 	}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -28,11 +28,11 @@ import (
 )
 
 const (
-	GIT_BASE_DIR        = "/git-base/"
-	SSH_PRIVATE_KEY_DIR = GIT_BASE_DIR + "ssh-keys/"
+	GIT_BASE_DIR              = "/git-base/"
+	SSH_PRIVATE_KEY_DIR       = GIT_BASE_DIR + "ssh-keys/"
 	SSH_PRIVATE_KEY_FILE_NAME = "ssh_pvt_key"
-	CLONE_TIMEOUT_SEC   = 600
-	FETCH_TIMEOUT_SEC   = 30
+	CLONE_TIMEOUT_SEC         = 600
+	FETCH_TIMEOUT_SEC         = 30
 )
 
 //git@gitlab.com:devtron-client-gitops/wms-user-management.git
@@ -57,7 +57,7 @@ func GetLocationForMaterial(material *sql.GitMaterial) (location string, err err
 		checkoutPath := path.Join(GIT_BASE_DIR, strconv.Itoa(material.Id), material.Url)
 		return checkoutPath, nil
 	}
-	
+
 	return "", fmt.Errorf("unsupported format url %s", material.Url)
 }
 
@@ -101,7 +101,6 @@ func GetOrCreateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent stri
 	return sshPrivateKeyFilePath, nil
 }
 
-
 func CreateOrUpdateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent string) error {
 	sshPrivateKeyFolderPath := path.Join(SSH_PRIVATE_KEY_DIR, strconv.Itoa(gitProviderId))
 	sshPrivateKeyFilePath := path.Join(sshPrivateKeyFolderPath, SSH_PRIVATE_KEY_FILE_NAME)
@@ -112,7 +111,7 @@ func CreateOrUpdateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent s
 	}
 
 	// create dirs
-	err := os.MkdirAll(sshPrivateKeyFolderPath, os.ModeDir)
+	err := os.MkdirAll(sshPrivateKeyFolderPath, 0764)
 	if err != nil {
 		return err
 	}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -87,7 +87,7 @@ func GetOrCreateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent stri
 	}
 
 	// create dirs
-	err = os.MkdirAll(sshPrivateKeyFolderPath, os.ModeDir)
+	err = os.MkdirAll(sshPrivateKeyFolderPath, 0764)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -87,7 +87,7 @@ func GetOrCreateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent stri
 	}
 
 	// create dirs
-	err = os.MkdirAll(sshPrivateKeyFolderPath, 0755)
+	err = os.MkdirAll(sshPrivateKeyFolderPath, 0600)
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +111,7 @@ func CreateOrUpdateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent s
 	}
 
 	// create dirs
-	err := os.MkdirAll(sshPrivateKeyFolderPath, 0755)
+	err := os.MkdirAll(sshPrivateKeyFolderPath, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -87,7 +87,7 @@ func GetOrCreateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent stri
 	}
 
 	// create dirs
-	err = os.MkdirAll(sshPrivateKeyFolderPath, 0600)
+	err = os.MkdirAll(sshPrivateKeyFolderPath, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +111,7 @@ func CreateOrUpdateSshPrivateKeyOnDisk(gitProviderId int, sshPrivateKeyContent s
 	}
 
 	// create dirs
-	err := os.MkdirAll(sshPrivateKeyFolderPath, 0600)
+	err := os.MkdirAll(sshPrivateKeyFolderPath, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The ssh-keys folder that gets stored in git sensor pod was being saved with 000 permission, so root user could access, but since the we have changed user from root to devtron, any other user could not access the ssh key, the git sensor was unable to fetch all the git commits for the git material that were configured via ssh. 

This pr will fix the issue as after this pr the I've given 755 access to the ssh-keys folder, as this was the same permission mode that we use to give to any git material inside the git sensor.

Tests:- Have tested it in my own cluster 