### PR TITLE
fix: invalid UTF-8 characters in commit message

### DIFF
--- a/api/GrpcHandler.go
+++ b/api/GrpcHandler.go
@@ -198,6 +198,9 @@ func (impl *GrpcHandlerImpl) FetchChanges(ctx context.Context, req *pb.FetchScmC
 		pbGitCommits = make([]*pb.GitCommit, 0, len(res.Commits))
 		for _, item := range res.Commits {
 			item.TruncateMessageIfExceedsMaxLength()
+			if !item.IsMessageValidUTF8() {
+				item.FixInvalidUTF8Message()
+			}
 			mappedCommit, err := impl.mapGitCommit(item)
 			if err != nil {
 				impl.logger.Debugw("failed to map git commit from bean to proto specified type",

--- a/pkg/git/Bean.go
+++ b/pkg/git/Bean.go
@@ -20,6 +20,7 @@ import (
 	"github.com/devtron-labs/git-sensor/internal/sql"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"time"
+	"unicode/utf8"
 )
 
 type FetchScmChangesRequest struct {
@@ -69,6 +70,22 @@ func (gitCommit *GitCommit) TruncateMessageIfExceedsMaxLength() {
 	if len(gitCommit.Message) > maxLength {
 		gitCommit.Message = gitCommit.Message[:maxLength-3] + "..."
 	}
+}
+
+// IsMessageValidUTF8 checks if a string is valid UTF-8.
+func (gitCommit *GitCommit) IsMessageValidUTF8() bool {
+	return utf8.ValidString(gitCommit.Message)
+}
+
+// FixInvalidUTF8Message replaces invalid UTF-8 sequences with the replacement character (U+FFFD).
+func (gitCommit *GitCommit) FixInvalidUTF8Message() {
+	invalidUTF8 := []rune(gitCommit.Message)
+	for i, r := range invalidUTF8 {
+		if !utf8.ValidRune(r) {
+			invalidUTF8[i] = utf8.RuneError
+		}
+	}
+	gitCommit.Message = string(invalidUTF8)
 }
 
 type WebhookAndCiData struct {

--- a/pkg/git/RepositoryManager.go
+++ b/pkg/git/RepositoryManager.go
@@ -307,6 +307,9 @@ func (impl RepositoryManagerImpl) ChangesSinceByRepository(repository *git.Repos
 				Message: commit.Message,
 			}
 			gitCommit.TruncateMessageIfExceedsMaxLength()
+			if !gitCommit.IsMessageValidUTF8() {
+				gitCommit.FixInvalidUTF8Message()
+			}
 			impl.logger.Debugw("commit dto for repo ", "repo", repository, commit)
 			gitCommits = append(gitCommits, gitCommit)
 			itrCounter = itrCounter + 1


### PR DESCRIPTION
# Description

For gRPC clients fetch git commits for pipelineId is breaking incase the commit message contains invalid UTF-8 characters.

Fixes https://github.com/devtron-labs/devtron/issues/3930

## How Has This Been Tested?
- [x] Existing Git Material
  - [x] commits having invalid UTF-8 in commit message
  - [x] valid commit messages
- [x] Create New Git Material
  - [x] commits having invalid UTF-8 in commit message
  - [x] valid commit messages

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
```release-note

```

