### PR TITLE
fix: handled parsing errors for diff --numstat command for diff output formats  and exposed CommitStatParsingErrorCounter prom metrics

### DIFF
--- a/internals/middleware/instrument.go
+++ b/internals/middleware/instrument.go
@@ -117,3 +117,11 @@ var PanicCounter = promauto.NewCounterVec(
 		ConstLabels: constLabels,
 	},
 	[]string{})
+
+var CommitStatParsingErrorCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name:        "commit_stats_parsing_errors_counter",
+		Help:        "total number of parsing errors encountered while processing git commit stats.",
+		ConstLabels: constLabels,
+	},
+	[]string{})

--- a/pkg/git/GitBaseManager.go
+++ b/pkg/git/GitBaseManager.go
@@ -283,7 +283,7 @@ func (impl *GitManagerBaseImpl) FetchDiffStatBetweenCommits(gitCtx GitContext, o
 
 	output, errMsg, err := impl.runCommandWithCred(cmd, gitCtx.Username, gitCtx.Password)
 	impl.logger.Debugw("root", rootDir, "opt", output, "errMsg", errMsg, "error", err)
-	if err != nil {
+	if err != nil || len(errMsg) > 0 {
 		impl.logger.Errorw("error in fetching fileStat diff btw commits: ", "oldHash", oldHash, "newHash", newHash, "checkoutPath", rootDir, "errorMsg", errMsg, "err", err)
 		return nil, err
 	}

--- a/pkg/git/GitCliManager.go
+++ b/pkg/git/GitCliManager.go
@@ -146,12 +146,7 @@ func (impl *GitCliManagerImpl) GitShow(gitCtx GitContext, rootDir string, hash s
 
 func (impl *GitCliManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
 	gitCommit := commit.GetCommit()
-	fileStat, errorMsg, err := impl.FetchDiffStatBetweenCommits(gitCtx, gitCommit.Commit, "", checkoutPath)
-	if err != nil {
-		impl.logger.Errorw("error in fetching fileStat of commit: ", gitCommit.Commit, "checkoutPath", checkoutPath, "errorMsg", errorMsg, "err", err)
-		return nil, err
-	}
-	return getFileStat(fileStat)
+	return impl.FetchDiffStatBetweenCommits(gitCtx, gitCommit.Commit, "", checkoutPath)
 }
 
 func (impl *GitCliManagerImpl) processGitLogOutput(out string) ([]GitCommit, error) {

--- a/pkg/git/GitFormatter.go
+++ b/pkg/git/GitFormatter.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -66,6 +67,7 @@ func parseFormattedLogOutput(out string) ([]GitCommitFormat, error) {
 	var gitCommitFormattedList []GitCommitFormat
 	err := json.Unmarshal([]byte(logOut), &gitCommitFormattedList)
 	if err != nil {
+		fmt.Printf("log output:- %s", logOut)
 		return nil, err
 	}
 	return gitCommitFormattedList, nil

--- a/pkg/git/GitFormatter.go
+++ b/pkg/git/GitFormatter.go
@@ -67,7 +67,7 @@ func parseFormattedLogOutput(out string) ([]GitCommitFormat, error) {
 	var gitCommitFormattedList []GitCommitFormat
 	err := json.Unmarshal([]byte(logOut), &gitCommitFormattedList)
 	if err != nil {
-		fmt.Sprintf("log output: %s, err: %v", logOut, err)
+		fmt.Println(fmt.Sprintf("log output: %s, err: %v", logOut, err))
 		return nil, err
 	}
 	return gitCommitFormattedList, nil

--- a/pkg/git/GitFormatter.go
+++ b/pkg/git/GitFormatter.go
@@ -67,7 +67,7 @@ func parseFormattedLogOutput(out string) ([]GitCommitFormat, error) {
 	var gitCommitFormattedList []GitCommitFormat
 	err := json.Unmarshal([]byte(logOut), &gitCommitFormattedList)
 	if err != nil {
-		fmt.Printf("log output:- %s", logOut)
+		fmt.Sprintf("log output: %s, err: %v", logOut, err)
 		return nil, err
 	}
 	return gitCommitFormattedList, nil

--- a/pkg/git/GoGitSDKManager.go
+++ b/pkg/git/GoGitSDKManager.go
@@ -123,7 +123,7 @@ func (impl *GoGitSDKManagerImpl) Init(gitCtx GitContext, rootDir string, remoteU
 }
 
 func (impl *GoGitSDKManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
-	if WasRepoShallowCloned(checkoutPath) {
+	if IsRepoShallowCloned(checkoutPath) {
 		return impl.GitManagerBase.FetchDiffStatBetweenCommits(gitCtx, commit.GetCommit().Commit, "", checkoutPath)
 	}
 	gitCommit := commit.(*GitCommitGoGit)

--- a/pkg/git/GoGitSDKManager.go
+++ b/pkg/git/GoGitSDKManager.go
@@ -123,7 +123,7 @@ func (impl *GoGitSDKManagerImpl) Init(gitCtx GitContext, rootDir string, remoteU
 }
 
 func (impl *GoGitSDKManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
-	if IsShallowCloningEnabled(checkoutPath) {
+	if WasRepoShallowCloned(checkoutPath) {
 		return impl.GitManagerBase.FetchDiffStatBetweenCommits(gitCtx, commit.GetCommit().Commit, "", checkoutPath)
 	}
 	gitCommit := commit.(*GitCommitGoGit)

--- a/pkg/git/GoGitSDKManager.go
+++ b/pkg/git/GoGitSDKManager.go
@@ -123,7 +123,7 @@ func (impl *GoGitSDKManagerImpl) Init(gitCtx GitContext, rootDir string, remoteU
 }
 
 func (impl *GoGitSDKManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
-	if IsShallowCloningEnabled(gitCtx.CloningMode, checkoutPath) {
+	if IsShallowCloningEnabled(checkoutPath) {
 		return impl.GitManagerBase.GetCommitStatsViaCli(gitCtx, commit, checkoutPath)
 	}
 	gitCommit := commit.(*GitCommitGoGit)

--- a/pkg/git/GoGitSDKManager.go
+++ b/pkg/git/GoGitSDKManager.go
@@ -124,7 +124,7 @@ func (impl *GoGitSDKManagerImpl) Init(gitCtx GitContext, rootDir string, remoteU
 
 func (impl *GoGitSDKManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
 	if IsShallowCloningEnabled(checkoutPath) {
-		return impl.GitManagerBase.GetCommitStatsViaCli(gitCtx, commit, checkoutPath)
+		return impl.GitManagerBase.FetchDiffStatBetweenCommits(gitCtx, commit.GetCommit().Commit, "", checkoutPath)
 	}
 	gitCommit := commit.(*GitCommitGoGit)
 

--- a/pkg/git/GoGitSDKManager.go
+++ b/pkg/git/GoGitSDKManager.go
@@ -123,6 +123,9 @@ func (impl *GoGitSDKManagerImpl) Init(gitCtx GitContext, rootDir string, remoteU
 }
 
 func (impl *GoGitSDKManagerImpl) GetCommitStats(gitCtx GitContext, commit GitCommit, checkoutPath string) (FileStats, error) {
+	if IsShallowCloningEnabled(gitCtx.CloningMode, checkoutPath) {
+		return impl.GitManagerBase.GetCommitStatsViaCli(gitCtx, commit, checkoutPath)
+	}
 	gitCommit := commit.(*GitCommitGoGit)
 
 	stats, err := gitCommit.Cm.Stats()

--- a/pkg/git/RepositoryManager.go
+++ b/pkg/git/RepositoryManager.go
@@ -315,12 +315,8 @@ func (impl *RepositoryManagerImpl) ChangesSinceByRepository(gitCtx GitContext, r
 					}
 				}()
 				//TODO: implement below Stats() function using git CLI as it panics in some cases, remove defer function after using git CLI
-				var stats FileStats
-				if IsShallowCloningEnabled(impl.configuration.CloningMode, checkoutPath) {
-					stats, err = impl.gitManager.GetCommitStatsViaCli(gitCtx, commit, repository.rootDir)
-				} else {
-					stats, err = impl.gitManager.GetCommitStats(gitCtx, commit, repository.rootDir)
-				}
+
+				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, repository.rootDir)
 				if err != nil {
 					impl.logger.Errorw("error in  fetching stats", "err", err)
 				}

--- a/pkg/git/RepositoryManager.go
+++ b/pkg/git/RepositoryManager.go
@@ -316,7 +316,12 @@ func (impl *RepositoryManagerImpl) ChangesSinceByRepository(gitCtx GitContext, r
 				}()
 				//TODO: implement below Stats() function using git CLI as it panics in some cases, remove defer function after using git CLI
 
-				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, checkoutPath)
+				statsCheckoutPath := repository.rootDir
+				if len(statsCheckoutPath) == 0 {
+					//TODO: needed this in case of go-git mode where we are executing cli command
+					statsCheckoutPath = checkoutPath
+				}
+				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, statsCheckoutPath)
 				if err != nil {
 					impl.logger.Errorw("error in  fetching stats", "err", err)
 				}

--- a/pkg/git/RepositoryManager.go
+++ b/pkg/git/RepositoryManager.go
@@ -315,8 +315,12 @@ func (impl *RepositoryManagerImpl) ChangesSinceByRepository(gitCtx GitContext, r
 					}
 				}()
 				//TODO: implement below Stats() function using git CLI as it panics in some cases, remove defer function after using git CLI
-
-				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, repository.rootDir)
+				var stats FileStats
+				if IsShallowCloningEnabled(impl.configuration.CloningMode, checkoutPath) {
+					stats, err = impl.gitManager.GetCommitStatsViaCli(gitCtx, commit, repository.rootDir)
+				} else {
+					stats, err = impl.gitManager.GetCommitStats(gitCtx, commit, repository.rootDir)
+				}
 				if err != nil {
 					impl.logger.Errorw("error in  fetching stats", "err", err)
 				}

--- a/pkg/git/RepositoryManager.go
+++ b/pkg/git/RepositoryManager.go
@@ -316,7 +316,7 @@ func (impl *RepositoryManagerImpl) ChangesSinceByRepository(gitCtx GitContext, r
 				}()
 				//TODO: implement below Stats() function using git CLI as it panics in some cases, remove defer function after using git CLI
 
-				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, repository.rootDir)
+				stats, err := impl.gitManager.GetCommitStats(gitCtx, commit, checkoutPath)
 				if err != nil {
 					impl.logger.Errorw("error in  fetching stats", "err", err)
 				}

--- a/pkg/git/RepositoryManagerAnalytics.go
+++ b/pkg/git/RepositoryManagerAnalytics.go
@@ -202,14 +202,9 @@ func (impl RepositoryManagerAnalyticsImpl) ChangesSinceByRepositoryForAnalytics(
 	if strings.Contains(checkoutPath, "/.git") || impl.configuration.UseGitCli {
 		oldHashString := oldHash.String()
 		newHashString := newHash.String()
-		outputMsg, errorMsg, err := impl.gitManager.FetchDiffStatBetweenCommits(gitCtx, oldHashString, newHashString, checkoutPath)
+		fileStats, err = impl.gitManager.FetchDiffStatBetweenCommits(gitCtx, oldHashString, newHashString, checkoutPath)
 		if err != nil {
-			impl.logger.Errorw("error in fetching fileStat diff between commits ", "errorMsg", errorMsg, "err", err)
-			return nil, err
-		}
-		fileStats, err = getFileStat(outputMsg)
-		if err != nil {
-			impl.logger.Errorw("can't convert git diff into fileStats ", "err", err)
+			impl.logger.Errorw("error in fetching fileStat diff between commits and converting git diff into fileStats ", "err", err)
 		}
 	} else {
 		patch, err := impl.getPatchObject(gitCtx, repository.Repository, oldHash, newHash)

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -156,7 +156,3 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 	return filestat, nil
 }
-
-func IsShallowCloningEnabled(cloningMode string, checkoutPath string) bool {
-	return cloningMode == CloningModeShallow && strings.Contains(checkoutPath, "/.git")
-}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -130,7 +130,7 @@ func getFileStat(commitDiff string) (FileStats, error) {
 		parts := strings.Split(line, "\t")
 
 		if len(parts) != 3 {
-			fmt.Sprintf("invalid git diff --numstat output")
+			fmt.Sprintf("invalid git diff --numstat output, parts: %v", parts)
 			continue
 		}
 

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -127,7 +127,12 @@ func getFileStat(commitDiff string) (FileStats, error) {
 	lines := strings.Split(strings.TrimSpace(commitDiff), "\n")
 
 	for _, line := range lines {
-		parts := strings.Fields(line)
+		parts := strings.Split(line, "\t")
+
+		if parts[0] == "-" && parts[1] == "-" {
+			// ignoring binary file
+			continue
+		}
 
 		if len(parts) != 3 {
 			fmt.Errorf("invalid git diff --numstat output")
@@ -150,4 +155,8 @@ func getFileStat(commitDiff string) (FileStats, error) {
 	}
 
 	return filestat, nil
+}
+
+func IsShallowCloningEnabled(cloningMode string, checkoutPath string) bool {
+	return cloningMode == CloningModeShallow && strings.Contains(checkoutPath, "/.git")
 }

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -139,6 +139,7 @@ func getFileStat(commitDiff string) (FileStats, error) {
 			continue
 		}
 
+		//TODO not ignoring in case of error in below cases because of include/exclude feature where file name is important
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
 			fmt.Printf("failed to parse number of lines added: %v\n", err)

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -156,6 +156,6 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 	return filestat, nil
 }
-func IsShallowCloningEnabled(checkoutPath string) bool {
+func WasRepoShallowCloned(checkoutPath string) bool {
 	return strings.Contains(checkoutPath, "/.git")
 }

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -156,6 +156,6 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 	return filestat, nil
 }
-func IsShallowCloningEnabled(cloningMode string, checkoutPath string) bool {
-	return cloningMode == CloningModeShallow && strings.Contains(checkoutPath, "/.git")
+func IsShallowCloningEnabled(checkoutPath string) bool {
+	return strings.Contains(checkoutPath, "/.git")
 }

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -130,7 +130,8 @@ func getFileStat(commitDiff string) (FileStats, error) {
 		parts := strings.Split(line, "\t")
 
 		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid git diff --numstat output")
+			fmt.Sprintf("invalid git diff --numstat output")
+			continue
 		}
 
 		if parts[0] == "-" && parts[1] == "-" {
@@ -140,13 +141,14 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
-			fmt.Println("failed to parse number of lines added: %w", err)
+			fmt.Sprintf("failed to parse number of lines added: %v", err)
 		}
 
 		deleted, err := strconv.Atoi(parts[1])
 		if err != nil {
-			fmt.Println("failed to parse number of lines deleted: %w", err)
+			fmt.Sprintf("failed to parse number of lines deleted: %v", err)
 		}
+
 		filestat = append(filestat, FileStat{
 			Name:     parts[2],
 			Addition: added,

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -130,17 +130,17 @@ func getFileStat(commitDiff string) (FileStats, error) {
 		parts := strings.Fields(line)
 
 		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid git diff --numstat output")
+			fmt.Errorf("invalid git diff --numstat output")
 		}
 
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse number of lines added: %w", err)
+			fmt.Errorf("failed to parse number of lines added: %w", err)
 		}
 
 		deleted, err := strconv.Atoi(parts[1])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse number of lines deleted: %w", err)
+			fmt.Errorf("failed to parse number of lines deleted: %w", err)
 		}
 		filestat = append(filestat, FileStat{
 			Name:     parts[2],

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -130,7 +130,7 @@ func getFileStat(commitDiff string) (FileStats, error) {
 		parts := strings.Split(line, "\t")
 
 		if len(parts) != 3 {
-			fmt.Sprintf("invalid git diff --numstat output, parts: %v", parts)
+			fmt.Printf("invalid git diff --numstat output, parts: %v\n", parts)
 			continue
 		}
 
@@ -141,12 +141,12 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
-			fmt.Sprintf("failed to parse number of lines added: %v", err)
+			fmt.Printf("failed to parse number of lines added: %v\n", err)
 		}
 
 		deleted, err := strconv.Atoi(parts[1])
 		if err != nil {
-			fmt.Sprintf("failed to parse number of lines deleted: %v", err)
+			fmt.Printf("failed to parse number of lines deleted: %v\n", err)
 		}
 
 		filestat = append(filestat, FileStat{

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -18,6 +18,7 @@ package git
 
 import (
 	"fmt"
+	"github.com/devtron-labs/git-sensor/internals/middleware"
 	"github.com/devtron-labs/git-sensor/internals/sql"
 	"io/ioutil"
 	"os"
@@ -131,6 +132,7 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 		if len(parts) != 3 {
 			fmt.Printf("invalid git diff --numstat output, parts: %v\n", parts)
+			middleware.CommitStatParsingErrorCounter.WithLabelValues().Inc()
 			continue
 		}
 
@@ -138,16 +140,21 @@ func getFileStat(commitDiff string) (FileStats, error) {
 			// ignoring binary file
 			continue
 		}
-
+		var isParsingError bool
 		//TODO not ignoring in case of error in below cases because of include/exclude feature where file name is important
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
 			fmt.Printf("failed to parse number of lines added: %v\n", err)
+			isParsingError = true
 		}
 
 		deleted, err := strconv.Atoi(parts[1])
 		if err != nil {
 			fmt.Printf("failed to parse number of lines deleted: %v\n", err)
+			isParsingError = true
+		}
+		if isParsingError {
+			middleware.CommitStatParsingErrorCounter.WithLabelValues().Inc()
 		}
 
 		filestat = append(filestat, FileStat{

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -156,3 +156,6 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 	return filestat, nil
 }
+func IsShallowCloningEnabled(cloningMode string, checkoutPath string) bool {
+	return cloningMode == CloningModeShallow && strings.Contains(checkoutPath, "/.git")
+}

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -156,6 +156,6 @@ func getFileStat(commitDiff string) (FileStats, error) {
 
 	return filestat, nil
 }
-func WasRepoShallowCloned(checkoutPath string) bool {
+func IsRepoShallowCloned(checkoutPath string) bool {
 	return strings.Contains(checkoutPath, "/.git")
 }

--- a/pkg/git/Util.go
+++ b/pkg/git/Util.go
@@ -129,23 +129,23 @@ func getFileStat(commitDiff string) (FileStats, error) {
 	for _, line := range lines {
 		parts := strings.Split(line, "\t")
 
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("invalid git diff --numstat output")
+		}
+
 		if parts[0] == "-" && parts[1] == "-" {
 			// ignoring binary file
 			continue
 		}
 
-		if len(parts) != 3 {
-			fmt.Errorf("invalid git diff --numstat output")
-		}
-
 		added, err := strconv.Atoi(parts[0])
 		if err != nil {
-			fmt.Errorf("failed to parse number of lines added: %w", err)
+			fmt.Println("failed to parse number of lines added: %w", err)
 		}
 
 		deleted, err := strconv.Atoi(parts[1])
 		if err != nil {
-			fmt.Errorf("failed to parse number of lines deleted: %w", err)
+			fmt.Println("failed to parse number of lines deleted: %w", err)
 		}
 		filestat = append(filestat, FileStat{
 			Name:     parts[2],


### PR DESCRIPTION
This Pr handles the parsing errors for diff --numstat command for diff output formats and have also exposed CommitStatParsingErrorCounter prom metrics for getting alerts for any other parsing errors

Fixes:- https://github.com/devtron-labs/devtron/issues/4799
